### PR TITLE
Fixed a bug which would be caused when 'inlinestyles=None' or 'linens=None'.

### DIFF
--- a/mistune_contrib/highlight.py
+++ b/mistune_contrib/highlight.py
@@ -38,6 +38,6 @@ def block_code(text, lang, inlinestyles=False, linenos=False):
 class HighlightMixin(object):
     def block_code(self, text, lang):
         # renderer has an options
-        inlinestyles = True if self.options.get('inlinestyles') else False
-        linenos = True if self.options.get('linenos') else False
+        inlinestyles = self.options.get('inlinestyles', False)
+        linenos = self.options.get('linenos', False)
         return block_code(text, lang, inlinestyles, linenos)

--- a/mistune_contrib/highlight.py
+++ b/mistune_contrib/highlight.py
@@ -38,6 +38,6 @@ def block_code(text, lang, inlinestyles=False, linenos=False):
 class HighlightMixin(object):
     def block_code(self, text, lang):
         # renderer has an options
-        inlinestyles = self.options.get('inlinestyles')
-        linenos = self.options.get('linenos')
+        inlinestyles = True if self.options.get('inlinestyles') else False
+        linenos = True if self.options.get('linenos') else False
         return block_code(text, lang, inlinestyles, linenos)


### PR DESCRIPTION
When I used the old codes, if I did not pass the value of inlinestyles or linenos, either of them were with the value of "None", and then would caused the bug as below.

Traceback (most recent call last):
  File "env/lib/python3.5/site-packages/mistune_contrib/highlight.py", line 28, in block_code
    noclasses=inlinestyles, linenos=linenos
  File "env/lib/python3.5/site-packages/pygments/formatters/html.py", line 388, in __init__
    self.noclasses = get_bool_opt(options, 'noclasses', False)
  File "env/lib/python3.5/site-packages/pygments/util.py", line 58, in get_bool_opt
    string, optname))
pygments.util.OptionError: Invalid type None for option noclasses; use 1/0, yes/no, true/false, on/off
