### PR TITLE
fix: add required output_block_math(); add synopsis

### DIFF
--- a/mistune_contrib/math.py
+++ b/mistune_contrib/math.py
@@ -9,6 +9,60 @@
     :copyright: (c) 2014 by Hsiaoming Yang.
 """
 
+
+"""
+    Usage: define your own block-lexer, inline-lexer, markdown engine and
+    renderer to customize math rendering.
+
+    from mistune import Markdown
+    from mistune import BlockLexer
+    from mistune import InlineLexer
+    from mistune import Renderer
+
+    class MathBlockLexer(MathBlockMixin, BlockLexer):
+        def __init__(self, *args, **kwargs):
+            super(MathBlockLexer, self).__init__(*args, **kwargs)
+            self.enable_math()
+
+
+    class MathInlineLexer(InlineLexer, MathInlineMixin):
+        def __init__(self, *args, **kwargs):
+            super(MathInlineLexer, self).__init__(*args, **kwargs)
+            self.enable_math()
+
+
+    class MathRenderer(Renderer, MathRendererMixin):
+        pass
+
+
+    class MathMarkdown(Markdown, MathMarkdownMixin):
+        pass
+
+    render = MathRenderer()
+    md = MathMarkdown(render,
+                      inline=MathInlineLexer(render),
+                      block=MathBlockLexer
+    )
+
+    print md('''
+    block math:
+
+    $$
+    y = x^2
+    $$
+
+    inline math: $ y = \\frac{1}{x} $''')
+
+    # output:
+    #     <p>block math:</p>
+    #
+    #     $$ this is my math:
+    #     y = x^2
+    #     $$
+    #     <p>inline math: $ this is my math:  y = \frac{1}{x} $</p>
+"""
+
+
 import re
 
 
@@ -94,56 +148,3 @@ class MathRendererMixin(object):
     def math(self, text):
         # override with customized math rendering
         return '$ math-renderer-mixin-inline: %s$' % text
-
-
-if __name__ == "__main__":
-
-    # Usage: define your own block-lexer, inline-lexer, markdown engine and
-    # renderer to customize math rendering.
-
-    from mistune import Markdown
-    from mistune import BlockLexer
-    from mistune import InlineLexer
-    from mistune import Renderer
-
-    class MathBlockLexer(MathBlockMixin, BlockLexer):
-        def __init__(self, *args, **kwargs):
-            super(MathBlockLexer, self).__init__(*args, **kwargs)
-            self.enable_math()
-
-
-    class MathInlineLexer(InlineLexer, MathInlineMixin):
-        def __init__(self, *args, **kwargs):
-            super(MathInlineLexer, self).__init__(*args, **kwargs)
-            self.enable_math()
-
-
-    class MathRenderer(Renderer, MathRendererMixin):
-        pass
-
-
-    class MathMarkdown(Markdown, MathMarkdownMixin):
-        pass
-
-    render = MathRenderer()
-    md = MathMarkdown(render,
-                      inline=MathInlineLexer(render),
-                      block=MathBlockLexer
-    )
-
-    print md('''
-block math:
-
-$$
-y = x^2
-$$
-
-inline math: $ y = \\frac{1}{x} $''')
-
-    # output:
-    #     <p>block math:</p>
-    #
-    #     $$ this is my math:
-    #     y = x^2
-    #     $$
-    #     <p>inline math: $ this is my math:  y = \frac{1}{x} $</p>

--- a/mistune_contrib/math.py
+++ b/mistune_contrib/math.py
@@ -25,7 +25,12 @@ class MathBlockMixin(object):
         self.rules.block_latex = re.compile(
             r'^\\begin\{([a-z]*\*?)\}(.*?)\\end\{\1\}', re.DOTALL
         )
-        self.default_rules.extend(['block_math', 'block_latex'])
+
+        # block_math must come before paragraph, or it is rendered as a normal paragraph
+        rs = self.default_rules
+        i = rs.index('paragraph')
+        rs.insert(i, 'block_latex')
+        rs.insert(i, 'block_math')
 
     def parse_block_math(self, m):
         """Parse a $$math$$ block"""
@@ -40,6 +45,17 @@ class MathBlockMixin(object):
             'name': m.group(1),
             'text': m.group(2)
         })
+
+
+
+class MathMarkdownMixin(object):
+
+    # block level token requires a output_* function
+    def output_block_math(self):
+        body = '\n'
+        body += self.renderer.block_math(self.token['text'])
+        body += '\n'
+        return body
 
 
 class MathInlineMixin(object):
@@ -62,10 +78,66 @@ class MathInlineMixin(object):
 
 class MathRendererMixin(object):
     def block_math(self, text):
-        return '$$%s$$' % text
+        # override with customized math rendering
+        return '$$ this is my math: %s$$' % text
 
     def block_latex(self, name, text):
-        return r'\begin{%s}%s\end{%s}' % (name, text, name)
+        # override with customized math rendering
+        return r' this is my math: \begin{%s}%s\end{%s}' % (name, text, name)
 
     def math(self, text):
-        return '$%s$' % text
+        # override with customized math rendering
+        return '$ this is my math: %s$' % text
+
+
+if __name__ == "__main__":
+
+    # Usage: define your own block-lexer, inline-lexer, markdown engine and
+    # renderer to customize math rendering.
+
+    from mistune import Markdown
+    from mistune import BlockLexer
+    from mistune import InlineLexer
+    from mistune import Renderer
+
+    class MathBlockLexer(MathBlockMixin, BlockLexer):
+        def __init__(self, *args, **kwargs):
+            super(MathBlockLexer, self).__init__(*args, **kwargs)
+            self.enable_math()
+
+
+    class MathInlineLexer(InlineLexer, MathInlineMixin):
+        def __init__(self, *args, **kwargs):
+            super(MathInlineLexer, self).__init__(*args, **kwargs)
+            self.enable_math()
+
+
+    class MathRenderer(Renderer, MathRendererMixin):
+        pass
+
+
+    class MathMarkdown(Markdown, MathMarkdownMixin):
+        pass
+
+    render = MathRenderer()
+    md = MathMarkdown(render,
+                      inline=MathInlineLexer(render),
+                      block=MathBlockLexer
+    )
+
+    print md('''
+block math:
+
+$$
+y = x^2
+$$
+
+inline math: $ y = \\frac{1}{x} $''')
+
+    # output:
+    #     <p>block math:</p>
+    #
+    #     $$ this is my math:
+    #     y = x^2
+    #     $$
+    #     <p>inline math: $ this is my math:  y = \frac{1}{x} $</p>

--- a/mistune_contrib/math.py
+++ b/mistune_contrib/math.py
@@ -57,6 +57,12 @@ class MathMarkdownMixin(object):
         body += '\n'
         return body
 
+    def output_block_latex(self):
+        body = '\n'
+        body += self.renderer.block_latex(self.token['name'],
+                                          self.token['text'])
+        body += '\n'
+        return body
 
 class MathInlineMixin(object):
     """Math mixin for InlineLexer, mix this with InlineLexer::
@@ -79,15 +85,15 @@ class MathInlineMixin(object):
 class MathRendererMixin(object):
     def block_math(self, text):
         # override with customized math rendering
-        return '$$ this is my math: %s$$' % text
+        return '$$ math-renderer-mixin-block: %s$$' % text
 
     def block_latex(self, name, text):
         # override with customized math rendering
-        return r' this is my math: \begin{%s}%s\end{%s}' % (name, text, name)
+        return r' math-renderer-mixin-latex: \begin{%s}%s\end{%s}' % (name, text, name)
 
     def math(self, text):
         # override with customized math rendering
-        return '$ this is my math: %s$' % text
+        return '$ math-renderer-mixin-inline: %s$' % text
 
 
 if __name__ == "__main__":

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -1,3 +1,9 @@
+from mistune import Markdown
+from mistune import BlockLexer
+from mistune import InlineLexer
+from mistune import Renderer
+from mistune_contrib import math
+
 MIXED_CASE = '''The entries of $C$ are given by the exact formula:
 $$
 C_{ik} = \sum_{j=1}^n A_{ij} B_{jk}
@@ -43,3 +49,57 @@ i.e. the $i^{th}$'''
 
 def test_paragraph():
     pass
+
+class MathBlockLexer(math.MathBlockMixin, BlockLexer):
+    def __init__(self, *args, **kwargs):
+        super(MathBlockLexer, self).__init__(*args, **kwargs)
+        self.enable_math()
+
+class MathInlineLexer(InlineLexer, math.MathInlineMixin):
+    def __init__(self, *args, **kwargs):
+        super(MathInlineLexer, self).__init__(*args, **kwargs)
+        self.enable_math()
+
+class MathRenderer(Renderer, math.MathRendererMixin):
+    pass
+
+class MathMarkdown(Markdown, math.MathMarkdownMixin):
+    pass
+
+def test_block_math():
+
+    md = MathMarkdown(MathRenderer(),
+                      block=MathBlockLexer)
+
+    res = md('''
+$$
+y = x^2
+$$
+''')
+
+    assert 'math-renderer-mixin-block' in res
+
+def test_inline_math():
+
+    r = MathRenderer()
+    md = MathMarkdown(r,
+                      inline=MathInlineLexer(r))
+
+    res = md('foo: $ y = x^2 $')
+
+    assert 'math-renderer-mixin-inline' in res
+
+def test_latex_math():
+
+    md = MathMarkdown(MathRenderer(),
+                      block=MathBlockLexer)
+
+    res = md('''
+\\begin{foo}
+y = x^2
+\\end{foo}
+''')
+
+    print res
+
+    assert 'math-renderer-mixin-latex' in res


### PR DESCRIPTION
## Cause:

I found that it does not render block math.
The complain is about a missing function `output_block_math()` which is required by a `Markdown` instance.

## My solution:

Thus I added a `output_block_math()` in a `Markdown` sub class.

## Explain:

From the `mistune.py` I see that
Customized inline lexer rendering functions are meant to be defined in a sub class of Renderer. But block level lexer rendering functions must be defined in a sub class of `Markdown`.

I do not know if I missed anything about the entire workflow or if there is another elegant way to fix it.

In order to let tests pass, lepture/mistune#185 must be applied first.

BTW. `mistune` is such a great work that saved me a lot time processing my own markdowns. 👍👍